### PR TITLE
Ability to specify the dissolve duration from javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ var SplashScreen = require('@remobile/react-native-splashscreen');
 
 var KitchenSink = React.createClass({
     componentDidMount: function() {
-        SplashScreen.hide();
+        SplashScreen.hide({
+          duration: 1 // Dissolve duration in seconds
+        });
     },
     render() {
         return(

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,4 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.facebook.react:react-native:0.13.+'
-    compile project(':react-native-cordova')
 }

--- a/ios/CRTSplashScreen/CRTSplashScreen.m
+++ b/ios/CRTSplashScreen/CRTSplashScreen.m
@@ -7,6 +7,7 @@
 //
 
 #import "CRTSplashScreen.h"
+#import "RCTConvert.h"
 
 static RCTRootView *rootView = nil;
 
@@ -31,7 +32,9 @@ RCT_EXPORT_MODULE(SplashScreen)
 }
 
 
-RCT_EXPORT_METHOD(hide) {
+RCT_EXPORT_METHOD(hide:(NSDictionary *)options) {
+    NSTimeInterval duration = [RCTConvert float:options[@"duration"]] ?: 1;
+
     if (!rootView) {
         return;
     }


### PR DESCRIPTION
Hello, and thanks for your work!
I added a parameter to the hide() function - it's an object which maps to a NSDictionary in objective-c. For now the only parameter supported is "duration", a float to specify the dissolve duration - but we could add a couple of settings to be controlled from javascript (i.e. the transition's type).
Anyone to update the Android code? :-)
