### PR TITLE
Fixes crash due to background display of Dialogs

### DIFF
--- a/android/src/main/java/com/remobile/splashscreen/RCTSplashScreen.java
+++ b/android/src/main/java/com/remobile/splashscreen/RCTSplashScreen.java
@@ -118,7 +118,9 @@ public class RCTSplashScreen extends ReactContextBaseJavaModule {
                 }
                 splashDialog.setContentView(splashImageView);
                 splashDialog.setCancelable(false);
-                splashDialog.show();
+                if (!activity.isFinishing()) {
+                    splashDialog.show();
+                }
             }
         });
     }


### PR DESCRIPTION
There is a crash when the dialog shown, checking if the activity is finishing before showing the dialog

http://dimitar.me/android-displaying-dialogs-from-background-threads/
