### PR TITLE
fix(docs): includes are incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
 ### Installation (Android)
 ```gradle
 ...
-include ':react-native-splashscreen'
-project(':react-native-splashscreen').projectDir = new File(settingsDir, '../node_modules/@remobile/react-native-splashscreen/android')
+include ':@remobile/react-native-splashscreen'
+project(':@remobile/react-native-splashscreen').projectDir = new File(rootProject.projectDir, '../node_modules/@remobile/react-native-splashscreen/android')
 ```
 
 * In `android/app/build.gradle`

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
 
 
 ### Installation (Android)
+
+* In `android/settings.gradle`
+
 ```gradle
 ...
 include ':@remobile/react-native-splashscreen'


### PR DESCRIPTION
Updating `settings.gradle` doc section to match what `react-native link` sets.  This will cause less confusion.